### PR TITLE
Fix black hole mass update after object absorption

### DIFF
--- a/Black hole/physics.js
+++ b/Black hole/physics.js
@@ -88,11 +88,13 @@ class PhysicsEngine {
             if (!object.absorbed) {
                 object.absorbed = true;
                 object.absorptionTime = 1.0;
-                this.blackHole.mass += object.mass / CONSTANTS.SOLAR_MASS;
+                // Convertir la masa del objeto a masas solares antes de añadirla
+                this.blackHole.mass += object.massKg / CONSTANTS.SOLAR_MASS;
+                // Recalcular propiedades del agujero negro con la nueva masa
                 this.blackHole.updateProperties();
+                }
+                return;
             }
-            return;
-        }
 
         // Calcular aceleración gravitacional
         const acceleration = this.calculateAcceleration(object, r);
@@ -285,6 +287,9 @@ class BlackHole {
     }
 
     updateProperties() {
+        // Actualizar masa en kilogramos según la masa en masas solares
+        this.massKg = this.mass * CONSTANTS.SOLAR_MASS;
+
         // Radio de Schwarzschild
         this.schwarzschildRadius = 2 * CONSTANTS.G * this.massKg / (CONSTANTS.c * CONSTANTS.c);
         


### PR DESCRIPTION
## Summary
- Correctly convert absorbed object mass to solar masses before adding to black hole
- Recalculate black hole properties by syncing mass in kilograms

## Testing
- `node --check 'Black hole/physics.js'`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad38c680f8832098ffd5751b074a20